### PR TITLE
Added code so marker colours are mapped to a gradient

### DIFF
--- a/src/pages/map-page.tsx
+++ b/src/pages/map-page.tsx
@@ -23,7 +23,8 @@ import { IntersectionType } from "typescript";
 import IntersectionCard from "../components/IntersectionCard";
 import {
   averageIntersectionTotalRedDuration,
-  getColourForTotalRedDuration,
+  createCanvasContext,
+  getMarkerColour,
 } from "../utils/utils";
 import GeocoderControl from "../utils/geocoder-control";
 import { LoadingTag } from "../styles/map-page.style";
@@ -71,6 +72,8 @@ export function MapComponent() {
   const [popupIntersection, setPopupIntersection] = React.useState<
     IntersectionStats | undefined
   >(undefined);
+
+  const context = createCanvasContext(); // Create canvas for colour of markers
 
   const [showPopup, setShowPopup] = React.useState(false);
 
@@ -156,9 +159,11 @@ export function MapComponent() {
           <GeolocateControl position="bottom-right" />
           <NavigationControl position="bottom-right" />
           {state.points
+          
             ? state.points.map((intersection: IntersectionStats) => {
                 const totalRedDuration =
                   averageIntersectionTotalRedDuration(intersection);
+                
                 return (
                   <Marker
                     key={intersection.osmId}
@@ -170,7 +175,7 @@ export function MapComponent() {
                         setShowPopup(true);
                       }
                     }}
-                    color={getColourForTotalRedDuration(totalRedDuration)}
+                    color={getMarkerColour(totalRedDuration, context)}
                   />
                 );
               })

--- a/src/pages/map-page.tsx
+++ b/src/pages/map-page.tsx
@@ -23,8 +23,7 @@ import { IntersectionType } from "typescript";
 import IntersectionCard from "../components/IntersectionCard";
 import {
   averageIntersectionTotalRedDuration,
-  createCanvasContext,
-  getMarkerColour,
+  getMarkerColour
 } from "../utils/utils";
 import GeocoderControl from "../utils/geocoder-control";
 import { LoadingTag } from "../styles/map-page.style";
@@ -72,8 +71,6 @@ export function MapComponent() {
   const [popupIntersection, setPopupIntersection] = React.useState<
     IntersectionStats | undefined
   >(undefined);
-
-  const context = createCanvasContext(); // Create canvas for colour of markers
 
   const [showPopup, setShowPopup] = React.useState(false);
 
@@ -175,7 +172,7 @@ export function MapComponent() {
                         setShowPopup(true);
                       }
                     }}
-                    color={getMarkerColour(totalRedDuration, context)}
+                    color={getMarkerColour(totalRedDuration)}
                   />
                 );
               })

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -100,57 +100,29 @@ export function tagListToRecord(tagList: RawTag[]): Record<OsmWayKeys, string> {
   return record;
 }
 
-function rgbToHex(r: number, g: number, b: number): string {
-  return ((r << 16) | (g << 8) | b).toString(16);
-}
-
-/* 
-Creates colour gradient for marker pins
-*/
-export function createCanvasContext(): CanvasRenderingContext2D| null  {
-
-  const canvas = document.createElement("canvas");
-  canvas.id = 'marker-colour-canvas';
-  canvas.width = 150;
-  canvas.height = 1;
-
-  const context = canvas.getContext('2d', { willReadFrequently: true });
-
-  if (context !== null) {
-    context.rect(0, 0, canvas.width, canvas.height);
-
-    const gradient = context.createLinearGradient(0, 0, canvas.width, canvas.height);
-    gradient.addColorStop(0, '#00FF00');
-    gradient.addColorStop(0.5, '#FFA500');
-    gradient.addColorStop(1, '#000000');
-  
-    context.fillStyle = gradient;
-    context.fill();
-
-    return context;
-
-  } else {
-
-    return null;
-  }
-
-}
-
 /*
 Returns colour for markers based on average cycle time
+if time > 150, returns black 
+else returns a gradient between green and red
 */
-export function getMarkerColour(avgCycleLegth : number, context: CanvasRenderingContext2D| null): string {
-
-  if (context !== null) {
-    const rgbValues = context.getImageData(avgCycleLegth, 0, 1, 1).data;
-    let color = "#" + ("000000" + rgbToHex(rgbValues[0], rgbValues[1], rgbValues[2])).slice(-6);
-
-    return color;
-  } else {
-
-    return '#00FF00';
+export function getMarkerColour(avgCycleLegth : number): string {
+  
+  if (avgCycleLegth >= 150) {
+    return 'hsl(0deg 0% 0%)';
   }
 
+  let hueVal: number = 120 - avgCycleLegth;
+  let colour: string = '';
+
+  if (hueVal < 0) { 
+    let lightness: number = 50 - (hueVal * -1);
+    colour = `hsl(0deg 100% ${lightness}%)`;
+
+  } else {   
+    colour = `hsl(${hueVal}deg 100% 50%)`; 
+  }
+
+  return colour;
 }
 
 export function getMainWayForIntersection(ways: Way[]): Way {


### PR DESCRIPTION
Adopted your idea of implementing colour for pins on a gradient. The colours to which avg. cycle times are mapped are - green, orange & black in increasing order of avg. cycle timings. 

I have created a canvas to which the cycle times are mapped. The width of this canvas is 150 i.e 0 seconds is the "green-est" and 150 seconds is the "black-est" and the midpoint is marked by orange. Any avg. cycle time that falls outside this range is coloured black. 

**A point for further discussion:** I chose this as 150 because most timings currently on the map fall just below this number. I could change this based on more information.

![Screenshot 2023-09-03 at 4 51 58 pm](https://github.com/jakecoppinger/better-intersections/assets/61399823/51bd6330-ee47-470c-a12f-38fbd09d62a1)
