### PR TITLE
Feature/two stage crossing radio

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -38,6 +38,9 @@ create table measurements (
 alter table measurements
   enable row level security;
 
+alter table measurements
+ADD is_two_stage_crossing text;
+
 create policy "Public measurements are viewable by everyone." on measurements
   for select using (true);
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -31,15 +31,14 @@ create table measurements (
 
   has_countdown_timer text, -- "yes" | "no" | "unknown"
 
+  is_two_stage_crossing text, -- "yes" | "no" | "unknown"
+
   notes text
 );
 -- Set up Row Level Security (RLS)
 -- See https://supabase.com/docs/guides/auth/row-level-security for more details.
 alter table measurements
   enable row level security;
-
-alter table measurements
-ADD is_two_stage_crossing text;
 
 create policy "Public measurements are viewable by everyone." on measurements
   for select using (true);

--- a/src/api/db.ts
+++ b/src/api/db.ts
@@ -6,7 +6,7 @@ export async function getIntersectionMeasurements(): Promise<SQLIntersectionWith
   const { data, error } = await supabase
     .from("measurements")
     .select(
-      `id,user_id,updated_at,custom_updated_at,location_description,green_light_duration,flashing_red_light_duration,solid_red_light_duration,osm_node_id,crossing_lantern_type,unprotected_crossing,intersection_id,is_scramble_crossing,has_countdown_timer,notes`
+      `id,user_id,updated_at,custom_updated_at,location_description,green_light_duration,flashing_red_light_duration,solid_red_light_duration,osm_node_id,crossing_lantern_type,unprotected_crossing,intersection_id,is_scramble_crossing,is_two_stage_crossing,has_countdown_timer,notes`
     );
 
   if (error) {

--- a/src/components/AuthenticatedContributeMeasurementForm.tsx
+++ b/src/components/AuthenticatedContributeMeasurementForm.tsx
@@ -18,6 +18,7 @@ import {
   IntersectionForm,
   IsScrambleCrossing,
   SQLIntersection,
+  IsTwoStageCrossing,
 } from "../types";
 import { FormTextInput, RadioButtonComponent } from "./form-components";
 import { SignalTimer } from "./SignalTimer";
@@ -373,6 +374,33 @@ export const AuthenticatedForm: React.FC<AuthenticatedFormProps> = (props) => {
             setFormState((prev) => ({
               ...prev,
               is_scramble_crossing,
+            }));
+          }}
+        />
+
+        <RadioButtonComponent<IsTwoStageCrossing>
+          title="Is it a two stage crossing?"
+          description="A two stage crossing is when a pedestrian has to cross a dual carriage way road with
+                      only one pedestrian light at the end of the crossing and the pedestrian is unable to cross in 
+                      one iteration of the light and hence has to wait in the middle "
+          id="is_two_stage_crossing"
+          selectedButton={formState.is_two_stage_crossing || undefined}
+          options={
+            [
+              {
+                value: "yes",
+                label: "Yes",
+              },
+              {
+                value: "no",
+                label: "No",
+              }
+            ] as { value: IsTwoStageCrossing; label: string }[]
+          }
+          callback={(is_two_stage_crossing: IsTwoStageCrossing) => {
+            setFormState((prev) => ({
+              ...prev,
+              is_two_stage_crossing,
             }));
           }}
         />

--- a/src/components/AuthenticatedContributeMeasurementForm.tsx
+++ b/src/components/AuthenticatedContributeMeasurementForm.tsx
@@ -98,6 +98,12 @@ export const AuthenticatedForm: React.FC<AuthenticatedFormProps> = (props) => {
         message: "Is scramble crossing is required",
       };
     }
+    if (raw.is_two_stage_crossing === undefined) {
+      return {
+        error: true,
+        message: "Missing form field - please add if it's a two-stage crossing"
+      };
+    }
 
     return { data: raw as IntersectionForm, error: false };
   }

--- a/src/components/AuthenticatedContributeMeasurementForm.tsx
+++ b/src/components/AuthenticatedContributeMeasurementForm.tsx
@@ -380,9 +380,9 @@ export const AuthenticatedForm: React.FC<AuthenticatedFormProps> = (props) => {
 
         <RadioButtonComponent<IsTwoStageCrossing>
           title="Is it a two stage crossing?"
-          description="A two stage crossing is when a pedestrian has to cross a dual carriage way road with
-                      only one pedestrian light at the end of the crossing and the pedestrian is unable to cross in 
-                      one iteration of the light and hence has to wait in the middle "
+          description="A two stage crossing is a crossing which requires a pedestrian to cross a dual carriage way road with
+                      only one pedestrian light at the end of the crossing, but the pedestrian is unable to legally cross in 
+                      one iteration of the light hence they have to wait in the middle of the crossing for the second iteration"
           id="is_two_stage_crossing"
           selectedButton={formState.is_two_stage_crossing || undefined}
           options={

--- a/src/components/AuthenticatedContributeMeasurementForm.tsx
+++ b/src/components/AuthenticatedContributeMeasurementForm.tsx
@@ -379,10 +379,10 @@ export const AuthenticatedForm: React.FC<AuthenticatedFormProps> = (props) => {
         />
 
         <RadioButtonComponent<IsTwoStageCrossing>
-          title="Is it a two stage crossing?"
-          description="A two stage crossing is a crossing which requires a pedestrian to cross a dual carriage way road with
-                      only one pedestrian light at the end of the crossing, but the pedestrian is unable to legally cross in 
-                      one iteration of the light hence they have to wait in the middle of the crossing for the second iteration"
+          title="Is it a two-stage crossing?"
+          description="A two-stage crossing is when pedestrian is unable to legally cross a 
+          dual-carriageway road in one cycle of the light - they have the wait at an island in 
+          the middle of the road."
           id="is_two_stage_crossing"
           selectedButton={formState.is_two_stage_crossing || undefined}
           options={
@@ -394,7 +394,11 @@ export const AuthenticatedForm: React.FC<AuthenticatedFormProps> = (props) => {
               {
                 value: "no",
                 label: "No",
-              }
+              },
+              {
+                value: "unknown",
+                label: "Unknown",
+              },
             ] as { value: IsTwoStageCrossing; label: string }[]
           }
           callback={(is_two_stage_crossing: IsTwoStageCrossing) => {

--- a/src/components/AuthenticatedContributeMeasurementForm.tsx
+++ b/src/components/AuthenticatedContributeMeasurementForm.tsx
@@ -101,7 +101,7 @@ export const AuthenticatedForm: React.FC<AuthenticatedFormProps> = (props) => {
     if (raw.is_two_stage_crossing === undefined) {
       return {
         error: true,
-        message: "Missing form field - please add if it's a two-stage crossing"
+        message: "Missing form field - please add if it's a two-stage crossing",
       };
     }
 
@@ -132,8 +132,9 @@ export const AuthenticatedForm: React.FC<AuthenticatedFormProps> = (props) => {
       alert(error.message);
     } else {
       alert("Measurement submitted, thanks! 🙏");
+      // TODO: Reset timing part of form (and possibly other uncontrolled fields)
+      setFormState({});
     }
-    setFormState({});
     setIsSubmitting(false);
   };
 
@@ -231,8 +232,11 @@ export const AuthenticatedForm: React.FC<AuthenticatedFormProps> = (props) => {
           geolocationStatus !== "Recorded intersection ID." && (
             <>
               <h2>Select intersection</h2>
-              <p>Select an intersection to take a measurement. If there is no pin at your desired location you
-                 you don't need to select a pin - but make sure to describe the location well in the textbox below.
+              <p>
+                Select an intersection to take a measurement. If there is no pin
+                at your desired location you you don't need to select a pin -
+                but make sure to describe the location well in the textbox
+                below.
               </p>
               <ReactMapGL
                 initialViewState={{
@@ -420,7 +424,6 @@ export const AuthenticatedForm: React.FC<AuthenticatedFormProps> = (props) => {
           description="What is the OpenStreetMap node ID of the crossing? This will be pre-filled if you clicked on a pin on the map above, please leave it!"
           value={formState.osm_node_id?.toString() || ""}
           placeholder="Optional. Eg: 11221625370"
-          
           setValue={(newVal: string) => {
             try {
               if (newVal === "") {

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,7 @@ export interface IntersectionFilterState {
 export type CrossingLanternType = "pedestrian" | "pedestrian_and_bicycle" | "bicycle";
 export type UnprotectedCrossing = "yes" | "no" | "delayed" | "not_sure";
 export type IsScrambleCrossing = "yes" | "no" | "unknown";
+export type IsTwoStageCrossing = "yes" | "no";
 export type HasCountdownTimer = "yes" | "no" | "unknown";
 export interface IntersectionForm {
   // /** UUID references auth.users on delete cascade. */
@@ -138,6 +139,9 @@ export interface IntersectionForm {
 
   /** Is it a scramble crossing? */
   is_scramble_crossing: IsScrambleCrossing | null;
+
+  /** Is it a two stage crossing? */
+  is_two_stage_crossing: IsTwoStageCrossing | null;
 
   has_countdown_timer: HasCountdownTimer | null;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,7 +93,7 @@ export interface IntersectionFilterState {
 export type CrossingLanternType = "pedestrian" | "pedestrian_and_bicycle" | "bicycle";
 export type UnprotectedCrossing = "yes" | "no" | "delayed" | "not_sure";
 export type IsScrambleCrossing = "yes" | "no" | "unknown";
-export type IsTwoStageCrossing = "yes" | "no";
+export type IsTwoStageCrossing = "yes" | "no" | "unknown";
 export type HasCountdownTimer = "yes" | "no" | "unknown";
 export interface IntersectionForm {
   // /** UUID references auth.users on delete cascade. */


### PR DESCRIPTION
![Screenshot 2023-09-29 at 12 19 25 pm](https://github.com/jakecoppinger/better-intersections/assets/61399823/961845f5-e804-450e-bbbb-713ff9bf17ae)

Have added a radio button for the user to indicate a two stage crossing in the form. Have further created a type for it "yes"|"no"|null and updated the associated types like the - IntersectionForm, had to update the db call as well.

prod DB has to be updated. @jakecoppinger I have added the alter command below to db.sql. You can directly change this in supabase as well.

`ALTER TABLE measurements
ADD is_two_stage_crossing text;`

Also, tested with my sample db in supabase and works fine. Adds null value for existing measurements. 

The description can be updated to explain the crossing better