### PR TITLE
UPDATE default imports to named imports

### DIFF
--- a/src/components/AuthenticatedContributeMeasurementForm.tsx
+++ b/src/components/AuthenticatedContributeMeasurementForm.tsx
@@ -1,12 +1,12 @@
-import React, { useEffect, useState } from "react";
-import ReactMapGL, {
+import { useEffect, useState, FC } from "react";
+import { 
   AttributionControl,
   FullscreenControl,
   GeolocateControl,
   Marker,
-} from "react-map-gl";
-import { Session } from "@supabase/supabase-js";
-
+  Map as ReactMapGL
+} from "react-map-gl/dist/esm/exports-mapbox"
+import { Session } from "@supabase/gotrue-js/src/lib/types";
 import { supabase } from "../utils/supabase-client";
 
 import {
@@ -27,7 +27,7 @@ export interface AuthenticatedFormProps {
   session: Session;
 }
 
-export const AuthenticatedForm: React.FC<AuthenticatedFormProps> = (props) => {
+export const AuthenticatedForm: FC<AuthenticatedFormProps> = (props) => {
   const { session } = props;
 
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/src/components/CsvExport.tsx
+++ b/src/components/CsvExport.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from "react";
+import { FunctionComponent, useState,  } from "react";
 import { getIntersectionMeasurements } from "../api/db";
 
 /**
@@ -13,7 +13,7 @@ export function normaliseField(field: string): string {
 }
 
 export const CsvExport: FunctionComponent = () => {
-  const [downloadStarted, setDownloadStarted] = React.useState(false);
+  const [downloadStarted, setDownloadStarted] = useState(false);
   const downloadCsv = async () => {
     try {
       const data = await getIntersectionMeasurements();

--- a/src/components/HeaderAndFooter.tsx
+++ b/src/components/HeaderAndFooter.tsx
@@ -1,5 +1,5 @@
-import { Link } from "react-router-dom";
-import React from "react";
+import { Link } from "react-router-dom/dist/index";
+import { FC, PropsWithChildren } from "react";
 import styled from "@emotion/styled";
 
 export const Wrapper = styled.div`
@@ -12,7 +12,7 @@ export const Wrapper = styled.div`
   }
 `;
 
-const HeaderAndFooter: React.FC<React.PropsWithChildren> = ({children}) => {
+export const HeaderAndFooter: FC<PropsWithChildren> = ({children}) => {
   return (
     <Wrapper>
       <h1><Link to={`/`}>Better Intersections</Link></h1>
@@ -21,4 +21,4 @@ const HeaderAndFooter: React.FC<React.PropsWithChildren> = ({children}) => {
   );
 };
 
-export default HeaderAndFooter;
+

--- a/src/components/IntersectionCard.tsx
+++ b/src/components/IntersectionCard.tsx
@@ -1,7 +1,6 @@
-import React from "react";
 import { IntersectionStats } from "../types";
 
-export default function IntersectionCard(props: {
+export function IntersectionCard(props: {
   intersection: IntersectionStats;
 }) {
   const { intersection } = props;

--- a/src/components/IntersectionFilter.tsx
+++ b/src/components/IntersectionFilter.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { RangeSlider } from "rsuite";
 import {
   FilterContainer,
@@ -13,7 +12,7 @@ import { IntersectionFilterState } from "../types";
  *
  * Can use in future to filter points by other attributes.
  */
-export default function IntersectionFilter(props: {
+export function IntersectionFilter(props: {
   /**
    * Should specify the minimum and maximum cycle times of the slider.
    * Min and max values should end in 5 (offset). Cycle time averages tend to be centred around

--- a/src/components/JsonExport.tsx
+++ b/src/components/JsonExport.tsx
@@ -1,8 +1,8 @@
-import React, { FunctionComponent } from "react";
+import { FunctionComponent, useState } from "react";
 import { getIntersectionMeasurements } from "../api/db";
 
 export const JsonExport: FunctionComponent = () => {
-  const [downloadStarted, setDownloadStarted] = React.useState(false);
+  const [downloadStarted, setDownloadStarted] = useState(false);
   const downloadCsv = async () => {
     try {
       const data = await getIntersectionMeasurements();

--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FC } from "react";
 import styled from "@emotion/styled";
 
 const LoadingWrapper = styled.div`
@@ -13,7 +13,7 @@ const LoadingWrapper = styled.div`
   padding: 5px 10px;
 `;
 
-export const LoadingIndicator: React.FC = () => (
+export const LoadingIndicator: FC = () => (
   <LoadingWrapper>
     <em>Loading data...</em>
   </LoadingWrapper>

--- a/src/components/MapInfoBox.tsx
+++ b/src/components/MapInfoBox.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
-import React, { FunctionComponent } from "react";
-import { Link } from "react-router-dom";
+import { FunctionComponent, useState } from "react";
+import { Link } from "react-router-dom/dist/index";
 
 
 const TitleBox = styled.div`
@@ -42,7 +42,7 @@ const DescriptionBox = styled.div`
 `;
 
 export const MapInfoBox: FunctionComponent = () => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
   return (
     <Wrapper>
       <TitleBox

--- a/src/components/PasswordlessLogin.tsx
+++ b/src/components/PasswordlessLogin.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState, FC } from "react";
 import { supabase } from "../utils/supabase-client";
 import { Session } from "@supabase/supabase-js";
 
@@ -13,7 +13,7 @@ export interface PasswordlessLoginProps {
   /** Session is null when not logged in */
   session: Session | null;
 }
-export const PasswordlessLogin: React.FC<PasswordlessLoginProps> = (
+export const PasswordlessLogin: FC<PasswordlessLoginProps> = (
   props: PasswordlessLoginProps
 ) => {
   const { session } = props;

--- a/src/components/SignalTimer.tsx
+++ b/src/components/SignalTimer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, MouseEventHandler, FC } from "react";
 import styled from "@emotion/styled";
 
 export interface SignalTimerCallback {
@@ -20,10 +20,10 @@ type SignalStateOptions =
 
 interface TrafficSignalProps {
   signalState: SignalStateOptions;
-  onclick: React.MouseEventHandler<any>;
+  onclick: MouseEventHandler<any>;
 }
 
-export const TrafficSignal: React.FC<TrafficSignalProps> = ({
+export const TrafficSignal: FC<TrafficSignalProps> = ({
   signalState,
   onclick,
 }: TrafficSignalProps) => {
@@ -103,7 +103,7 @@ interface TimeDisplayProps {
   solidRedStartTime: number | null;
   nextCycleStartTime: number | null;
 }
-export const TimeDisplay: React.FC<TimeDisplayProps> = ({
+export const TimeDisplay: FC<TimeDisplayProps> = ({
   greenStartTime,
   flashingRedStartTime,
   solidRedStartTime,
@@ -161,7 +161,7 @@ const generateCurrentSignalState = (
   return stateLookup[newPressCount] || "next-cycle";
 };
 
-export const SignalTimer: React.FC<SignalTimerProps> = ({
+export const SignalTimer: FC<SignalTimerProps> = ({
   callback,
 }: SignalTimerProps) => {
   /** The number of times the button has been pressed. If 0 times, light is grey. If 1, green.
@@ -232,7 +232,7 @@ export const SignalTimer: React.FC<SignalTimerProps> = ({
     return textIndex[pressCount];
   }
 
-  const handleClick: React.MouseEventHandler<HTMLButtonElement> = (e): void => {
+  const handleClick: MouseEventHandler<HTMLButtonElement> = (e): void => {
     e.preventDefault();
     if (pressCount < 4) {
       setPressCount(pressCount + 1);

--- a/src/components/form-components.tsx
+++ b/src/components/form-components.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { ChangeEvent } from "react";
 import styled from "@emotion/styled";
 
 const PaddedLabel = styled.label`
@@ -91,7 +91,7 @@ export function RadioButtonComponent<T extends string>({
   title,
   description,
 }: RadioButtonComponentProps<T>) {
-  const handleRadioChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleRadioChange = (event: ChangeEvent<HTMLInputElement>) => {
     const newVal: T = event.target.value as T;
     callback(newVal);
   };

--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -1,5 +1,5 @@
-import React, { FunctionComponent} from 'react';
-import ReactDOM from 'react-dom';
+import { FunctionComponent, Fragment} from 'react';
+import ReactDOM from 'react-dom/index';
 import {
   Wrapper,
   Header,
@@ -22,7 +22,7 @@ export const Modal: FunctionComponent<ModalProps> = ({
   headerText,
 }) => {
   const modal = (
-    <React.Fragment>
+    <Fragment>
       <Backdrop />
       <Wrapper>
         <StyledModal>
@@ -33,7 +33,7 @@ export const Modal: FunctionComponent<ModalProps> = ({
           <Content>{modalContent}</Content>
         </StyledModal>
       </Wrapper>
-    </React.Fragment>
+    </Fragment>
   );
   return isShown ? ReactDOM.createPortal(modal, document.body) : null;
 };

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect } from "react";
-import HeaderAndFooter from "../components/HeaderAndFooter";
-import { Link } from "react-router-dom";
+import { FC } from "react";
+import { HeaderAndFooter } from "../components/HeaderAndFooter";
+import { Link } from "react-router-dom/dist/index";
 import { CsvExport } from "../components/CsvExport";
 import { JsonExport } from "../components/JsonExport";
 
-const About: React.FC = () => {
+const About: FC = () => {
   return (
     <HeaderAndFooter>
       <div>

--- a/src/pages/contribute-measurement-page.tsx
+++ b/src/pages/contribute-measurement-page.tsx
@@ -1,12 +1,12 @@
-import React, { useState, useEffect } from "react";
-import HeaderAndFooter from "../components/HeaderAndFooter";
-import { Session } from "@supabase/supabase-js";
+import { useState, useEffect, FC } from "react";
+import { HeaderAndFooter } from "../components/HeaderAndFooter";
+import { Session } from "@supabase/gotrue-js/src/lib/types";
 import { supabase } from "../utils/supabase-client";
 import { AuthenticatedForm } from "../components/AuthenticatedContributeMeasurementForm";
 import { PasswordlessLogin } from "../components/PasswordlessLogin";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom/dist/index";
 
-export const ContributeMeasurementPage: React.FC = () => {
+export const ContributeMeasurementPage: FC = () => {
   const [session, setSession] = useState<Session | null>(null);
 
   useEffect(() => {

--- a/src/pages/intersection-node-page.tsx
+++ b/src/pages/intersection-node-page.tsx
@@ -2,7 +2,7 @@ import { useLoaderData, LoaderFunctionArgs } from "react-router-dom";
 import React, { useState, useEffect } from "react";
 import { fetchOsmWaysForNode } from "../api/osm";
 import { IntersectionStats, Way } from "../types";
-import HeaderAndFooter from "../components/HeaderAndFooter";
+import { HeaderAndFooter } from "../components/HeaderAndFooter";
 import {
   generateGeohackQueryParam,
   googleStreetViewUrl,

--- a/src/pages/longest-and-shortest-waits-page.tsx
+++ b/src/pages/longest-and-shortest-waits-page.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { fetchOsmWaysForNode } from "../api/osm";
 import { IntersectionStats, Way } from "../types";
-import HeaderAndFooter from "../components/HeaderAndFooter";
+import { HeaderAndFooter } from "../components/HeaderAndFooter";
 import {
   averageIntersectionTotalRedDuration,
   filterOutNonRoadWays,

--- a/src/pages/map-page.tsx
+++ b/src/pages/map-page.tsx
@@ -1,19 +1,19 @@
-import React from "react";
-import ReactMapGL, {
-  MapboxMap,
+import { useState, useEffect } from "react";
+import { Map as MapboxMap } from "react-map-gl/node_modules/@types/mapbox-gl/index";
+import { 
   AttributionControl,
   FullscreenControl,
   GeolocateControl,
   Marker,
   Popup,
   ViewStateChangeEvent,
-} from "react-map-gl";
+  Map
+} from "react-map-gl/dist/esm/exports-mapbox"
 import "../App.css";
 import { MapInfoBox } from "../components/MapInfoBox";
 import { IntersectionFilterState, IntersectionStats } from "../types";
-
 import "mapbox-gl/dist/mapbox-gl.css";
-import IntersectionCard from "../components/IntersectionCard";
+import { IntersectionCard } from "../components/IntersectionCard";
 import {
   averageIntersectionTotalRedDuration,
   getIntersections,
@@ -21,7 +21,7 @@ import {
   getMaxCycleTime,
   getNextLargestMultipleOf5,
 } from "../utils/utils";
-import IntersectionFilter from "../components/IntersectionFilter";
+import { IntersectionFilter } from "../components/IntersectionFilter";
 import { LoadingIndicator } from "../components/LoadingIndicator";
 
 const MAPBOX_TOKEN =
@@ -62,14 +62,14 @@ type Viewport = {
 };
 
 export function MapComponent() {
-  const [state, setState] = React.useState<State>(initialState);
-  const [popupIntersection, setPopupIntersection] = React.useState<
+  const [state, setState] = useState<State>(initialState);
+  const [popupIntersection, setPopupIntersection] = useState<
     IntersectionStats | undefined
   >(undefined);
 
-  const [showPopup, setShowPopup] = React.useState(false);
+  const [showPopup, setShowPopup] = useState(false);
 
-  const [viewport, setViewport] = React.useState<Viewport>({
+  const [viewport, setViewport] = useState<Viewport>({
     longitude,
     latitude, // starting position
     zoom,
@@ -77,9 +77,9 @@ export function MapComponent() {
   const defaultMinMax = { min: 15, max: 185 };
 
   const [{ min, max }, setCycleTimeFilter] =
-    React.useState<IntersectionFilterState>(defaultMinMax);
+    useState<IntersectionFilterState>(defaultMinMax);
 
-  React.useEffect(() => {
+  useEffect(() => {
     async function getIntersectionsWrapper() {
       const intersections = await getIntersections();
       setState((s) => ({
@@ -133,7 +133,7 @@ export function MapComponent() {
       />
       <div id="map">
         {state.points === undefined && <LoadingIndicator></LoadingIndicator>}
-        <ReactMapGL
+        <Map
           initialViewState={viewport}
           mapboxAccessToken={MAPBOX_TOKEN}
           id={"react-map"}
@@ -189,7 +189,7 @@ export function MapComponent() {
             </Popup>
           ) : null}
           {/* Todo add search  */}
-        </ReactMapGL>
+        </Map>
       </div>
     </div>
   );

--- a/src/utils/supabase-client.ts
+++ b/src/utils/supabase-client.ts
@@ -1,4 +1,4 @@
-import { createClient} from "@supabase/supabase-js";
+import { createClient } from "@supabase/supabase-js";
 
 const supabaseUrl = "https://wcwrjovyjkqowlnsjtnl.supabase.co";
 const supabaseAnonKey =

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react-jsx"
   },
   "include": [
     "src"


### PR DESCRIPTION
Hey Jake
I changed the import naming. I don't think it made a huge difference. It might have cleaned up the code a little bit. I ran the bundle analyser which shows - 

![Screenshot 2023-10-23 at 8 19 05 pm](https://github.com/jakecoppinger/better-intersections/assets/61399823/698c6200-2e2c-4653-b4c5-968e79f632ee)

As far as I can tell most of this is because of interdependencies within the package. I am not sure what cloudflare includes to show ~10MB as you mentioned in the issue.

This might be helpful if not already done - https://create-react-app.dev/docs/production-build/#static-file-caching

Larger changes to bundles can be made with lazy loading and by changing the webpack config file which I believe is hidden from the user in create-react-app. I am not sure if there is more low hanging fruit here though.