### PR TITLE
created function to convert to local;called in popup;called in intersection-node-page

### DIFF
--- a/src/components/IntersectionCard.tsx
+++ b/src/components/IntersectionCard.tsx
@@ -1,4 +1,5 @@
 import { IntersectionStats } from "../types";
+import { convertUTCtoLocal } from "../utils/utils";
 
 export function IntersectionCard(props: {
   intersection: IntersectionStats;
@@ -29,7 +30,7 @@ export function IntersectionCard(props: {
           <tr>
             <th>Time</th>
             {intersection.reports.map((r) => (
-              <td key={r.timestamp.toString()}>{r.timestamp.toString()}</td>
+              <td key={r.timestamp.toString()}>{convertUTCtoLocal(r.timestamp.toString())}</td>
             ))}
           </tr>
           <tr>

--- a/src/pages/intersection-node-page.tsx
+++ b/src/pages/intersection-node-page.tsx
@@ -8,6 +8,7 @@ import {
   googleStreetViewUrl,
 } from "../utils/url-formatting";
 import {
+  convertUTCtoLocal,
   filterOutNonRoadWays,
   getIntersections,
   getMainWayForIntersection,
@@ -123,7 +124,7 @@ export default function IntersectionNodePage() {
             ) : (
               intersection.reports.map((r) => (
                 <tr key={r.osmId}>
-                  <td>{r.timestamp.toString()}</td>
+                  <td>{convertUTCtoLocal(r.timestamp.toString())}</td>
                   <td>
                     <span className="green">{r.greenDuration} sec.</span>
                   </td>

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -237,3 +237,14 @@ export async function getIntersections(): Promise<IntersectionStats[]> {
     return [];
   }
 }
+
+export function convertUTCtoLocal(UTCtime: string): string {
+  const dateObject = new Date(UTCtime);
+  const localTime = dateObject.toString();
+  
+  if (localTime === "Invalid Date") {
+    return `${UTCtime} (local Sydney time)`;
+  } else{
+    return localTime;
+  }
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -238,12 +238,16 @@ export async function getIntersections(): Promise<IntersectionStats[]> {
   }
 }
 
+/** 
+ * Formats UTC time (or any ISO8601 date string) into the browsers local timezone.
+ * If date is invalid, returns the original string.
+ */
 export function convertUTCtoLocal(UTCtime: string): string {
   const dateObject = new Date(UTCtime);
   const localTime = dateObject.toString();
   
   if (localTime === "Invalid Date") {
-    return `${UTCtime} (local Sydney time)`;
+    return UTCtime;
   } else{
     return localTime;
   }


### PR DESCRIPTION
I added a function to utils to convert the string coming from the db to javascript date. JS Date automatically converts it to browser's local time. There are some instances of the legacy google form timestamp, which is basically just a time HH:MM:SS, it doesn't seem to have an associated date, so it cannot be converted and hence I have made an exception to leave that as it is. 

![Screenshot 2023-12-22 at 3 39 12 am](https://github.com/jakecoppinger/better-intersections/assets/61399823/4be8bbfb-0a69-479a-a2fc-daaed25f7797)
![Screenshot 2023-12-22 at 3 39 43 am](https://github.com/jakecoppinger/better-intersections/assets/61399823/71b0b9e8-c36e-434f-b6ed-ce449405b90b)
![Screenshot 2023-12-22 at 3 39 58 am](https://github.com/jakecoppinger/better-intersections/assets/61399823/041fc15f-8c3d-4646-81cd-561bb2591a4a)
![Screenshot 2023-12-22 at 3 44 03 am](https://github.com/jakecoppinger/better-intersections/assets/61399823/c2bd07d8-a11e-460d-b06d-e4aec2d2c512)
