### PR TITLE
ADD long, lat to measurements table

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -33,7 +33,10 @@ create table measurements (
 
   is_two_stage_crossing text, -- "yes" | "no" | "unknown"
 
-  notes text
+  notes text,
+  -- latitude & longitude of the node
+  latitude float,
+  longitude float
 );
 -- Set up Row Level Security (RLS)
 -- See https://supabase.com/docs/guides/auth/row-level-security for more details.

--- a/src/api/db.ts
+++ b/src/api/db.ts
@@ -8,7 +8,7 @@ export async function getIntersectionMeasurements(): Promise<IntersectionMeasure
     // user_id is not excluded here for security reasons -
     // user_id references a record in the (locked down) auth table
     .select(
-      `id,updated_at,custom_updated_at,location_description,green_light_duration,flashing_red_light_duration,solid_red_light_duration,osm_node_id,crossing_lantern_type,unprotected_crossing,intersection_id,is_scramble_crossing,is_two_stage_crossing,has_countdown_timer,notes`
+      `id,updated_at,custom_updated_at,location_description,green_light_duration,flashing_red_light_duration,solid_red_light_duration,osm_node_id,crossing_lantern_type,unprotected_crossing,intersection_id,is_scramble_crossing,is_two_stage_crossing,has_countdown_timer,notes,longitude,latitude`
     );
 
   if (error) {

--- a/src/components/AuthenticatedContributeMeasurementForm.tsx
+++ b/src/components/AuthenticatedContributeMeasurementForm.tsx
@@ -308,6 +308,8 @@ You'll need to manually find the intersection.`)
                         setFormState((prev) => ({
                           ...prev,
                           osm_node_id: intersection.id,
+                          latitude: intersection.lat,
+                          longitude: intersection.lon
                         }));
                         setGeolocationStatus("Recorded intersection ID.");
                       }}

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,7 +160,7 @@ export interface IntersectionForm {
   /** Additional notes. */
   notes: string | null;
 
-  /** TEST long & LAT */
+  /** latitude and longitude of the node*/
   latitude: number|null;
   longitude: number|null;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,6 +159,10 @@ export interface IntersectionForm {
 
   /** Additional notes. */
   notes: string | null;
+
+  /** TEST long & LAT */
+  latitude: number|null;
+  longitude: number|null;
 }
 
 /** The fields needed to create a new intersection measurement */


### PR DESCRIPTION
Hey Jake, this is the first PR for #42 

I have added the float value for lat and long, to the form type. When a user chooses a node, its lat and long gets recorded when making a new measurement. I have used float, I believe it offers more precision than real . **You can now update the db to fill the null values for lat and long for existing measurements.** . I will make more PRs for the rest of it