### PR TITLE
Look up pin locations in DB, save pin locations into DB

### DIFF
--- a/src/api/osm.ts
+++ b/src/api/osm.ts
@@ -80,6 +80,22 @@ async function requestRawOsmNode(osmNode: number): Promise<any> {
   return osmApiResult.osm.node[0];
 }
 
+/**
+ * Fetch the position of an OSM node from the OSM API.
+ * If the node does not exist or any error occurs, returns {lat: null, lon: null}.
+ */
+export async function attemptFindNodeLocation(osmNode: number | undefined | null): Promise<{lat: number | null, lon: number | null}> {
+  if(osmNode === undefined || osmNode === null) {
+    return {lat: null, lon: null};
+  }
+  try {
+  const node = await requestOsmNodePosition(osmNode);
+  return {lat: node.lat, lon: node.lon};
+  } catch (e) {
+    console.warn(`Failed to fetch lat/lon for OSM node ${osmNode} during submission, leaving it out. Error: ${e}`);
+    return {lat: null, lon: null};
+  }
+}
 
 /**
  * Attempt to fetch the position of an OSM node from the OSM API.

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export interface TrafficLightReport {
   /** Derived field. Length of full cycle */
   cycleLength: number,
   /** OSM tags on the intersection node */
-  tags: Record<string, string>
+  // tags: Record<string, string>
   /** Is the crossing unprotected when flashing red? Boolean or null when unknown */
   unprotectedOnFlashingRed: boolean | null
 }
@@ -45,7 +45,7 @@ export interface IntersectionStats {
   lon: number,
   reports: TrafficLightReport[];
   /** OSM tags for the intersection */
-  tags: Record<string, string>;
+  // tags: Record<string, string>;
 }
 
 export interface Way {
@@ -161,8 +161,8 @@ export interface IntersectionForm {
   notes: string | null;
 
   /** latitude and longitude of the node*/
-  latitude: number|null;
-  longitude: number|null;
+  latitude: number | null;
+  longitude: number | null;
 }
 
 /** The fields needed to create a new intersection measurement */

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,8 +31,6 @@ export interface TrafficLightReport {
   notes?: string,
   /** Derived field. Length of full cycle */
   cycleLength: number,
-  /** OSM tags on the intersection node */
-  // tags: Record<string, string>
   /** Is the crossing unprotected when flashing red? Boolean or null when unknown */
   unprotectedOnFlashingRed: boolean | null
 }
@@ -44,8 +42,6 @@ export interface IntersectionStats {
   lat: number,
   lon: number,
   reports: TrafficLightReport[];
-  /** OSM tags for the intersection */
-  // tags: Record<string, string>;
 }
 
 export interface Way {
@@ -160,7 +156,7 @@ export interface IntersectionForm {
   /** Additional notes. */
   notes: string | null;
 
-  /** latitude and longitude of the node*/
+  /** Latitude and Longitude of the measurement, fetched from OSM. */
   latitude: number | null;
   longitude: number | null;
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -59,7 +59,6 @@ export function summariseReportsByIntersection(reports: TrafficLightReport[]): I
       stats[report.osmId] = {
         osmId: report.osmId,
         reports: [report],
-        // tags: report.tags,
         lat: report.lat,
         lon: report.lon,
       }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -28,7 +28,6 @@ export async function convertToTrafficLightReport(formResponse: IntersectionMeas
   }
   try {
     const { lat, lon } = await getOsmNodePosition(osm_node_id, nodeIdLocationLookup)
-    // const { lat, lon, tags } = await getOsmNodePosition(osm_node_id)
 
     const val = {
       osmId: osm_node_id,
@@ -39,7 +38,6 @@ export async function convertToTrafficLightReport(formResponse: IntersectionMeas
       redDuration: solid_red_light_duration,
       notes: notes || undefined,
       timestamp: timestampOverride && timestampOverride.length > 0 ? timestampOverride : updated_at,
-      // tags: tags,
       unprotectedOnFlashingRed,
     }
     const cycleLength = val.greenDuration + val.flashingDuration + val.redDuration;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -2,19 +2,15 @@ import { getIntersectionMeasurements } from "../api/db";
 import { getOsmNodePosition, logOSMCacheStats, requestOsmNodePosition } from "../api/osm";
 import { IntersectionStats, OsmWayKeys, RawTag, IntersectionMeasurementResult, TrafficLightReport, Way, OSMNode } from "../types";
 
-
-function isStringInteger(str: string): boolean {
-  const num = Number(str);
-  return !isNaN(num) && parseInt(str, 10) === num;
-}
-
 /** Returns true if the form response has an OpenStreetMap node id, and so can be displayed */
 export function isValidTrafficLightReport(formResponse: IntersectionMeasurementResult): boolean {
   const rawOsmId = formResponse.osm_node_id;
   return rawOsmId !== null;
 }
 
-export async function convertToTrafficLightReport(formResponse: IntersectionMeasurementResult): Promise<TrafficLightReport | null> {
+export async function convertToTrafficLightReport(formResponse: IntersectionMeasurementResult, 
+  nodeIdLocationLookup: Record<number, { lat: number, lon: number}>): Promise<TrafficLightReport | null> {
+
   const { osm_node_id, custom_updated_at, unprotected_crossing,
     green_light_duration,
     flashing_red_light_duration,
@@ -31,7 +27,8 @@ export async function convertToTrafficLightReport(formResponse: IntersectionMeas
     throw new Error(`No osm id in field: ${osm_node_id}`);
   }
   try {
-    const { lat, lon, tags } = await getOsmNodePosition(osm_node_id)
+    const { lat, lon } = await getOsmNodePosition(osm_node_id, nodeIdLocationLookup)
+    // const { lat, lon, tags } = await getOsmNodePosition(osm_node_id)
 
     const val = {
       osmId: osm_node_id,
@@ -42,7 +39,7 @@ export async function convertToTrafficLightReport(formResponse: IntersectionMeas
       redDuration: solid_red_light_duration,
       notes: notes || undefined,
       timestamp: timestampOverride && timestampOverride.length > 0 ? timestampOverride : updated_at,
-      tags: tags,
+      // tags: tags,
       unprotectedOnFlashingRed,
     }
     const cycleLength = val.greenDuration + val.flashingDuration + val.redDuration;
@@ -54,8 +51,6 @@ export async function convertToTrafficLightReport(formResponse: IntersectionMeas
   }
 }
 
-
-
 export function summariseReportsByIntersection(reports: TrafficLightReport[]): IntersectionStats[] {
   const stats: Record<string, IntersectionStats> = {};
   reports.forEach(report => {
@@ -66,7 +61,7 @@ export function summariseReportsByIntersection(reports: TrafficLightReport[]): I
       stats[report.osmId] = {
         osmId: report.osmId,
         reports: [report],
-        tags: report.tags,
+        // tags: report.tags,
         lat: report.lat,
         lon: report.lon,
       }
@@ -215,6 +210,26 @@ export function getNextLargestMultipleOf5(val: number) {
   return Math.ceil(val / 5) * 5;
 }
 
+/**
+ * Generates a record mapping node IDs to an object containing their latitude and longitude
+ */
+export function buildNodeIdLocationLookup(measurements: IntersectionMeasurementResult[]): Record<number, { lat: number, lon: number}> {
+  const lookup: Record<string, { lat: number, lon: number }> = {};
+  /** measurements sorted by time, so that we preserve the most recent coordinate of an OSM node */
+  const sortedMeasurements = measurements.sort((a, b) => {
+    const aTime = new Date(a.updated_at).getTime();
+    const bTime = new Date(b.updated_at).getTime();
+    return bTime - aTime;
+  });
+  sortedMeasurements.forEach((measurement) => {
+    const {osm_node_id, latitude, longitude} = measurement;
+    if (osm_node_id && latitude && longitude) {
+      lookup[osm_node_id] = { lat: latitude, lon: longitude};
+    }
+  });
+  return lookup;
+}
+
 export async function getIntersections(): Promise<IntersectionStats[]> {
   let data: IntersectionMeasurementResult[] = []
   try {
@@ -225,6 +240,7 @@ export async function getIntersections(): Promise<IntersectionStats[]> {
     console.log(e);
     return [];
   }
+  const nodeIdLocationLookup = buildNodeIdLocationLookup(data);
   const safeData = data.filter(measurement => measurement.osm_node_id);
 
   // Turn this on if you want to generate a new cache!
@@ -261,7 +277,7 @@ export async function getIntersections(): Promise<IntersectionStats[]> {
     const reportsOrNull: (TrafficLightReport | null)[] = await Promise.all(
       safeData
         .filter(isValidTrafficLightReport)
-        .map(convertToTrafficLightReport)
+        .map(measurement => convertToTrafficLightReport(measurement, nodeIdLocationLookup))
     );
     logOSMCacheStats();
 


### PR DESCRIPTION
This provides an initial implementation of fetching node locations from the DB and storing them when creating a submission.

It also provides a fallback when a node cannot be found on the OSM API - it checks for the second to last version in the history API and attempts to get the location from there.

Addresses #42